### PR TITLE
Allow deprecation warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![crate_name = "static"]
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(deprecated)]
 #![feature(phase)]
 
 //! Static file-serving handler.


### PR DESCRIPTION
If deprecation warnings fail the build, then there's no point in
deprecation (in place of outright removal) in the first place.
