### PR TITLE
rename this package to staticfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing
 
-**static** uses the same conventions as **[Iron](https://github.com/iron/iron)**.
+**staticfile** uses the same conventions as **[Iron](https://github.com/iron/iron)**.
 
 ### Overview
 
-* Fork static to your own account
+* Fork staticfile to your own account
 * Create a feature branch, namespaced by.
   * bug/...
   * feat/...

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 
-name = "static"
+name = "staticfile"
 version = "0.0.4"
 authors = ["Zach Pomerantz <zmp@umich.edu>"]
 description = "Static file serving for Iron."
-repository = "https://github.com/iron/static"
+repository = "https://github.com/iron/staticfile"
 license = "MIT"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-static [![Build Status](https://secure.travis-ci.org/iron/static.png?branch=master)](https://travis-ci.org/iron/static)
+staticfile [![Build Status](https://secure.travis-ci.org/iron/staticfile.png?branch=master)](https://travis-ci.org/iron/staticfile)
 ====
 
 > Static file-serving handler for the [Iron](https://github.com/iron/iron) web framework.
@@ -13,20 +13,18 @@ let mut mount = Mount::new();
 // Serve the shared JS/CSS at /
 mount.mount("/", Static::new(Path::new("target/doc/")));
 // Serve the static file docs at /doc/
-mount.mount("/doc/", Static::new(Path::new("target/doc/static/")));
+mount.mount("/doc/", Static::new(Path::new("target/doc/staticfile/")));
 // Serve the source code at /src/
-mount.mount("/src/", Static::new(Path::new("target/doc/src/static/lib.rs.html")));
+mount.mount("/src/", Static::new(Path::new("target/doc/src/staticfile/lib.rs.html")));
 
 Iron::new(mount).listen(Ipv4Addr(127, 0, 0, 1), 3000).unwrap();
 ```
-
-Note that `static` is a reserved keyword, so the crate will need to be imported as `extern crate "static" as static_file;`.
 
 See [`examples/doc_server.rs`](examples/doc_server.rs) for a complete example that you can compile.
 
 ## Overview
 
-static is a part of Iron's [core bundle](https://github.com/iron/core).
+staticfile is a part of Iron's [core bundle](https://github.com/iron/core).
 
 - Serve static files from a given path.
 
@@ -34,19 +32,19 @@ It works well in combination with the [mounting handler][mounting-handler].
 
 ## Installation
 
-If you're using a `Cargo.toml` to manage dependencies, just add the `static` package to the toml:
+If you're using a `Cargo.toml` to manage dependencies, just add the `staticfile` package to the toml:
 
 ```toml
-[dependencies.static]
+[dependencies.staticfile]
 
-git = "https://github.com/iron/static.git"
+git = "https://github.com/iron/staticfile.git"
 ```
 
 Otherwise, `cargo build`, and the rlib will be in your `target` directory.
 
-## [Documentation](http://ironframework.io/doc/static)
+## [Documentation](http://ironframework.io/doc/staticfile)
 
-Along with the [online documentation](http://ironframework.io/doc/static),
+Along with the [online documentation](http://ironframework.io/doc/staticfile),
 you can build a local copy with `cargo doc`.
 
 ## Get Help

--- a/examples/doc_server.rs
+++ b/examples/doc_server.rs
@@ -1,10 +1,10 @@
 #![feature(path)]
 
 extern crate iron;
-extern crate "static" as static_file;
+extern crate staticfile;
 extern crate mount;
 
-// This example serves the docs from target/doc/static at /doc/
+// This example serves the docs from target/doc/staticfile at /doc/
 //
 // Run `cargo doc && cargo test && ./target/doc_server`, then
 // point your browser to http://127.0.0.1:3000/doc/
@@ -12,7 +12,7 @@ extern crate mount;
 use std::path::Path;
 
 use iron::Iron;
-use static_file::Static;
+use staticfile::Static;
 use mount::Mount;
 
 fn main() {
@@ -21,9 +21,9 @@ fn main() {
     // Serve the shared JS/CSS at /
     mount.mount("/", Static::new(Path::new("target/doc/")));
     // Serve the static file docs at /doc/
-    mount.mount("/doc/", Static::new(Path::new("target/doc/static/")));
+    mount.mount("/doc/", Static::new(Path::new("target/doc/staticfile/")));
     // Serve the source code at /src/
-    mount.mount("/src/", Static::new(Path::new("target/doc/src/static/lib.rs.html")));
+    mount.mount("/src/", Static::new(Path::new("target/doc/src/staticfile/lib.rs.html")));
 
     println!("Doc server running on http://localhost:3000/doc/");
 

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -18,13 +18,13 @@
 extern crate iron;
 extern crate mount;
 extern crate router;
-extern crate "static" as static_file;
+extern crate staticfile;
 
 use iron::status;
 use iron::{Iron, Request, Response, IronResult};
 use mount::Mount;
 use router::Router;
-use static_file::Static;
+use staticfile::Static;
 use std::path::Path;
 
 fn say_hello(req: &mut Request) -> IronResult<Response> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![crate_name = "static"]
+#![crate_name = "staticfile"]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![feature(std_misc, path_ext, fs_time)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "static"]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(core, std_misc, path_ext, fs_time)]
+#![feature(std_misc, path_ext, fs_time)]
 
 //! Static file-serving handler.
 

--- a/src/requested_path.rs
+++ b/src/requested_path.rs
@@ -1,14 +1,15 @@
 use iron::Request;
-use std::path::{PathBuf, AsPath};
+use std::path::{PathBuf, Path};
 use std::fs::PathExt;
+use std::convert::AsRef;
 
 pub struct RequestedPath {
     pub path: PathBuf,
 }
 
 impl RequestedPath {
-    pub fn new<P: AsPath>(root_path: P, request: &Request) -> RequestedPath {
-        let mut path = root_path.as_path().to_path_buf();
+    pub fn new<P: AsRef<Path>>(root_path: P, request: &Request) -> RequestedPath {
+        let mut path = root_path.as_ref().to_path_buf();
 
         path.extend(&request.url.path);
 
@@ -17,9 +18,8 @@ impl RequestedPath {
 
     pub fn should_redirect(&self, request: &Request) -> bool {
         let last_url_element = request.url.path
-            .as_slice()
             .last()
-            .map(|s| s.as_slice());
+            .map(|s| s.as_ref());
 
         // As per servo/rust-url/serialize_path, URLs ending in a slash have an
         // empty string stored as the last component of their path. Rust-url

--- a/tests/cache.rs
+++ b/tests/cache.rs
@@ -5,7 +5,7 @@ extern crate time;
 extern crate hyper;
 extern crate iron;
 extern crate "iron-test" as iron_test;
-extern crate "static" as static_file;
+extern crate staticfile;
 
 use time::Timespec;
 
@@ -14,7 +14,7 @@ use iron::method::Method::Get;
 use iron::status::Status;
 use hyper::header::{IfModifiedSince, CacheControl, CacheDirective, LastModified};
 use iron_test::{mock, ProjectBuilder};
-use static_file::Static;
+use staticfile::Static;
 use std::io;
 use std::time::Duration;
 

--- a/tests/static.rs
+++ b/tests/static.rs
@@ -3,14 +3,14 @@
 extern crate hyper;
 extern crate iron;
 extern crate "iron-test" as iron_test;
-extern crate "static" as static_file;
+extern crate staticfile;
 
 use hyper::header::Location;
 use iron::method::Method::Get;
 use iron::{Url, Handler};
 use iron::status::Status;
 use iron_test::{mock, ProjectBuilder};
-use static_file::Static;
+use staticfile::Static;
 use std::io;
 
 #[test]


### PR DESCRIPTION
As discussed on IRC, the new `extern _ as _` syntax doesn't allow quotes
in the first parameter anymore, preventing us from using that as a
workaround for the fact that the package name is also a keyword.

This renames everything (I hope I didn't miss anything) to staticfile,
including:

* crate name
* repo url
* travis url
* readme occurrences
* examples
* documentation url
