### PR TITLE
(feat) make it usable on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,19 @@ description = "Static file serving for Iron."
 repository = "https://github.com/iron/staticfile"
 license = "MIT"
 
+[features]
+cache = ["filetime"]
+
 [dependencies]
 iron = "*"
 mount = "*"
 time = "*"
 router = "*"
 log = "*"
-filetime = "*"
+
+[dependencies.filetime]
+version = "*"
+optional = true
 
 [dev-dependencies]
 iron-test = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 #![crate_name = "staticfile"]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(path_ext, duration)]
+#![cfg_attr(feature = "cache", feature(path_ext, duration))]
 
 //! Static file-serving handler.
 
 extern crate time;
+
+#[cfg(feature = "cache")]
 extern crate filetime;
 
 extern crate iron;
@@ -13,7 +15,9 @@ extern crate iron;
 extern crate log;
 extern crate mount;
 
-pub use static_handler::{Static, Cache};
+pub use static_handler::Static;
+#[cfg(feature = "cache")]
+pub use static_handler::Cache;
 
 mod requested_path;
 mod static_handler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "staticfile"]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![cfg_attr(feature = "cache", feature(path_ext, duration))]
+#![cfg_attr(feature = "cache", feature(duration))]
 
 //! Static file-serving handler.
 

--- a/src/static_handler.rs
+++ b/src/static_handler.rs
@@ -1,13 +1,14 @@
 use std::path::{PathBuf, Path};
-use std::fs::PathExt;
-use std::time::Duration;
+use std::fs;
 use std::error::Error;
 use std::fmt;
-use time::{self, Timespec};
-use filetime::FileTime;
+
+#[cfg(feature = "cache")]
+use time::{self, Timespec, Duration};
 
 use iron::prelude::*;
 use iron::{Handler, status};
+#[cfg(feature = "cache")]
 use iron::modifier::Modifier;
 use iron::modifiers::Redirect;
 use mount::OriginalUrl;
@@ -30,6 +31,7 @@ use requested_path::RequestedPath;
 pub struct Static {
     /// The path this handler is serving files from.
     pub root: PathBuf,
+    #[cfg(feature = "cache")]
     cache: Option<Cache>,
 }
 
@@ -37,8 +39,22 @@ impl Static {
     /// Create a new instance of `Static` with a given root path.
     ///
     /// If `Path::new("")` is given, files will be served from the current directory.
+    #[cfg(feature = "cache")]
     pub fn new<P: AsRef<Path>>(root: P) -> Static {
-        Static { root: root.as_ref().to_path_buf(), cache: None }
+        Static {
+            root: root.as_ref().to_path_buf(),
+            cache: None
+        }
+    }
+
+    /// Create a new instance of `Static` with a given root path.
+    ///
+    /// If `Path::new("")` is given, files will be served from the current directory.
+    #[cfg(not(feature = "cache"))]
+    pub fn new<P: AsRef<Path>>(root: P) -> Static {
+        Static {
+            root: root.as_ref().to_path_buf(),
+        }
     }
 
     /// Specify the response's `cache-control` header with a given duration. Internally, this is
@@ -49,10 +65,12 @@ impl Static {
     /// ```ignore
     /// let cached_static_handler = Static::new(path).cache(Duration::from_secs(30*24*60*60));
     /// ```
+    #[cfg(feature = "cache")]
     pub fn cache(self, duration: Duration) -> Static {
         self.set(Cache::new(duration))
     }
 
+    #[cfg(feature = "cache")]
     fn try_cache<P: AsRef<Path>>(&self, req: &mut Request, path: P) -> IronResult<Response> {
         match self.cache {
             None => Ok(Response::with((status::Ok, path.as_ref()))),
@@ -63,11 +81,26 @@ impl Static {
 
 impl Handler for Static {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        use std::io;
+
         let requested_path = RequestedPath::new(&self.root, req);
+
+        let metadata = match fs::metadata(&requested_path.path) {
+            Ok(meta) => meta,
+            Err(e) => {
+                let status = match e.kind() {
+                    io::ErrorKind::NotFound => status::NotFound,
+                    io::ErrorKind::PermissionDenied => status::Forbidden,
+                    _ => status::InternalServerError,
+                };
+
+                return Err(IronError::new(e, status))
+            },
+        };
 
         // If the URL ends in a slash, serve the file directly.
         // Otherwise, redirect to the directory equivalent of the URL.
-        if requested_path.should_redirect(req) {
+        if requested_path.should_redirect(&metadata, req) {
             // Perform an HTTP 301 Redirect.
             let mut redirect_path = match req.extensions.get::<OriginalUrl>() {
                 None => &req.url,
@@ -85,11 +118,17 @@ impl Handler for Static {
                                       Redirect(redirect_path))));
         }
 
-        match requested_path.get_file() {
+        match requested_path.get_file(&metadata) {
             // If no file is found, return a 404 response.
             None => Err(IronError::new(NoFile, status::NotFound)),
             // Won't panic because we know the file exists from get_file.
+            #[cfg(feature = "cache")]
             Some(path) => self.try_cache(req, path),
+            #[cfg(not(feature = "cache"))]
+            Some(path) => {
+                let path: &Path = &path;
+                Ok(Response::with((status::Ok, path)))
+            },
         }
     }
 }
@@ -97,12 +136,14 @@ impl Handler for Static {
 impl Set for Static {}
 
 /// A modifier for `Static` to specify a response's `cache-control`.
+#[cfg(feature = "cache")]
 #[derive(Clone)]
 pub struct Cache {
     /// The length of time the file should be cached for.
     pub duration: Duration,
 }
 
+#[cfg(feature = "cache")]
 impl Cache {
     /// Create a new instance of `Cache` with a given duration.
     pub fn new(duration: Duration) -> Cache {
@@ -111,11 +152,14 @@ impl Cache {
 
     fn handle<P: AsRef<Path>>(&self, req: &mut Request, path: P) -> IronResult<Response> {
         use iron::headers::{IfModifiedSince, HttpDate};
+
         let path = path.as_ref();
 
-        let last_modified_time = match path.metadata() {
+        let last_modified_time = match fs::metadata(path) {
             Err(error) => return Err(IronError::new(error, status::InternalServerError)),
             Ok(metadata) => {
+                use filetime::FileTime;
+
                 let time = FileTime::from_last_modification_time(&metadata);
                 Timespec::new(time.seconds() as i64, time.nanoseconds() as i32)
             },
@@ -145,6 +189,7 @@ impl Cache {
     }
 }
 
+#[cfg(feature = "cache")]
 impl Modifier<Static> for Cache {
     fn modify(self, static_handler: &mut Static) {
         static_handler.cache = Some(self);

--- a/src/static_handler.rs
+++ b/src/static_handler.rs
@@ -4,7 +4,9 @@ use std::error::Error;
 use std::fmt;
 
 #[cfg(feature = "cache")]
-use time::{self, Timespec, Duration};
+use time::{self, Timespec};
+#[cfg(feature = "cache")]
+use std::time::Duration;
 
 use iron::prelude::*;
 use iron::{Handler, status};

--- a/tests/cache.rs
+++ b/tests/cache.rs
@@ -7,7 +7,10 @@ extern crate iron;
 extern crate iron_test;
 extern crate staticfile;
 
-use time::{Duration, Timespec};
+use time::{Timespec};
+
+#[cfg(feature = "cache")]
+use std::time::Duration;
 
 use iron::{Handler, Url};
 use iron::method::Method::Get;
@@ -21,6 +24,7 @@ use iron_test::mock::MockStream;
 use staticfile::Static;
 use std::io::Cursor;
 
+#[cfg(feature = "cache")]
 #[test]
 fn it_should_return_cache_headers() {
     let p = ProjectBuilder::new("example").file("file1.html", "this is file1");
@@ -44,6 +48,7 @@ fn it_should_return_cache_headers() {
     }
 }
 
+#[cfg(feature = "cache")]
 #[test]
 fn it_should_return_the_file_if_client_sends_no_modified_time() {
     let p = ProjectBuilder::new("example").file("file1.html", "this is file1");
@@ -61,6 +66,7 @@ fn it_should_return_the_file_if_client_sends_no_modified_time() {
     }
 }
 
+#[cfg(feature = "cache")]
 #[test]
 fn it_should_return_the_file_if_client_has_old_version() {
     let p = ProjectBuilder::new("example").file("file1.html", "this is file1");
@@ -82,6 +88,7 @@ fn it_should_return_the_file_if_client_has_old_version() {
     }
 }
 
+#[cfg(feature = "cache")]
 #[test]
 fn it_should_return_304_if_client_has_file_cached() {
     let p = ProjectBuilder::new("example").file("file1.html", "this is file1");
@@ -100,6 +107,7 @@ fn it_should_return_304_if_client_has_file_cached() {
     }
 }
 
+#[cfg(feature = "cache")]
 #[test]
 fn it_should_cache_index_html_for_directory_path() {
     let p = ProjectBuilder::new("example").file("dir/index.html", "this is index");
@@ -118,6 +126,7 @@ fn it_should_cache_index_html_for_directory_path() {
     }
 }
 
+#[cfg(feature = "cache")]
 #[test]
 fn it_should_defer_to_static_handler_if_directory_misses_trailing_slash() {
     let p = ProjectBuilder::new("example").file("dir/index.html", "this is index");

--- a/tests/cache.rs
+++ b/tests/cache.rs
@@ -1,4 +1,4 @@
-#![feature(duration)]
+#![cfg_attr(feature = "cache", feature(duration))]
 
 extern crate time;
 
@@ -7,7 +7,7 @@ extern crate iron;
 extern crate iron_test;
 extern crate staticfile;
 
-use time::Timespec;
+use time::{Duration, Timespec};
 
 use iron::{Handler, Url};
 use iron::method::Method::Get;
@@ -20,7 +20,6 @@ use iron_test::{mock, ProjectBuilder};
 use iron_test::mock::MockStream;
 use staticfile::Static;
 use std::io::Cursor;
-use std::time::Duration;
 
 #[test]
 fn it_should_return_cache_headers() {


### PR DESCRIPTION
This introduces the `cache` feature which enables the caching
functionality. At the moment this is only usable in nightly rust.

As a side-effect, a request to a file for which the process doesn't have
permission to read yields an HTTP 403: Forbidden status, non-existent
file requests yield an HTTP 404: Not Found status, and any other error
yields an HTTP 500: Internal Server Error status.