### PR TITLE
Allow caching to work on stable Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![crate_name = "staticfile"]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![cfg_attr(feature = "cache", feature(duration))]
 
 //! Static file-serving handler.
 

--- a/src/static_handler.rs
+++ b/src/static_handler.rs
@@ -183,7 +183,7 @@ impl Cache {
         use iron::headers::{CacheControl, LastModified, CacheDirective, HttpDate};
 
         let mut response = Response::with((status::Ok, path.as_ref()));
-        let seconds = self.duration.secs() as u32;
+        let seconds = self.duration.as_secs() as u32;
         let cache = vec![CacheDirective::Public, CacheDirective::MaxAge(seconds)];
         response.headers.set(CacheControl(cache));
         response.headers.set(LastModified(HttpDate(time::at(modified))));


### PR DESCRIPTION
The Duration API is no longer unstable, and doesn't need a feature gate. This commit removes the feature gate and updates the usage to compile on stable Rust, allowing caching without requiring use of the nightly.