### PR TITLE
(fix) added support of percent-encoded chars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ mount = "0"
 time = "0.1"
 log = "0.3"
 
+[dependencies.url]
+git = "https://github.com/servo/rust-url"
+
 [dependencies.filetime]
 version = "0.1"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ optional = true
 
 [dev-dependencies]
 iron-test = "0"
-hyper = "0.6"
+hyper = "0.7"
 router = "0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate iron;
 #[macro_use]
 extern crate log;
 extern crate mount;
+extern crate url;
 
 pub use static_handler::Static;
 #[cfg(feature = "cache")]

--- a/src/requested_path.rs
+++ b/src/requested_path.rs
@@ -2,16 +2,22 @@ use iron::Request;
 use std::path::{PathBuf, Path};
 use std::fs::{self, Metadata};
 use std::convert::AsRef;
+use url::percent_encoding::percent_decode;
 
 pub struct RequestedPath {
     pub path: PathBuf,
 }
 
+#[inline]
+fn decode_percents(string: &String) -> String {
+    String::from_utf8(percent_decode(string.as_bytes())).unwrap()
+}
+
 impl RequestedPath {
     pub fn new<P: AsRef<Path>>(root_path: P, request: &Request) -> RequestedPath {
         let mut path = root_path.as_ref().to_path_buf();
-
-        path.extend(&request.url.path);
+        let decoded_req_path = request.url.path.iter().map(decode_percents);
+        path.extend(decoded_req_path);
 
         RequestedPath { path: path }
     }

--- a/tests/static.rs
+++ b/tests/static.rs
@@ -98,3 +98,23 @@ fn redirects_if_trailing_slash_is_missing() {
         Err(e) => panic!("{}", e)
     }
 }
+
+#[test]
+fn decodes_percent_notation() {
+    let p = ProjectBuilder::new("example").file("has space.html", "file with funky chars");
+    p.build();
+    let st = Static::new(p.root().clone());
+    let mut stream = MockStream::new(Cursor::new("".to_string().into_bytes()));
+    let mut reader = BufReader::new(&mut stream as &mut NetworkStream);
+    let mut req = mock::request::new(Get,
+                                     Url::parse("http://localhost:3000/has space.html").unwrap(),
+                                     &mut reader);
+    match st.handle(&mut req) {
+        Ok(res) => {
+            let mut body = Vec::new();
+            res.body.unwrap().write_body(&mut ResponseBody::new(&mut body)).unwrap();
+            assert_eq!(str::from_utf8(&body).unwrap(), "file with funky chars");
+        },
+        Err(e) => panic!("{}", e)
+    }
+}


### PR DESCRIPTION
First commit adds ability to build the project (resolved `hyper` version clash). 
Second commit fixes #60.