### PR TITLE
Avoid extension with empty strings

### DIFF
--- a/src/requested_path.rs
+++ b/src/requested_path.rs
@@ -17,7 +17,9 @@ impl RequestedPath {
     pub fn new<P: AsRef<Path>>(root_path: P, request: &Request) -> RequestedPath {
         let mut result = root_path.as_ref().to_path_buf();
         let path = request.url.path();
-        let decoded_req_path = path.iter().map(decode_percents);
+        let decoded_req_path = path.iter()
+          .map(decode_percents)
+          .filter(|x| x.len() != 0);
         result.extend(decoded_req_path);
 
         RequestedPath { path: result }


### PR DESCRIPTION
The empty strings causes the `result` to become completely
empty, the reproduction case contains [""] in the iterator.
Due to the path being empty, no file could be downloaded.
By filtering the empty paths, we avoid overwriting the original
url requesting path.

The example would fail with an internal error because the path
ends in "/", whilst we're actually requesting a file name specifically.