### PR TITLE
Add Partial Content Delivery

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,4 @@ pub use static_handler::Cache;
 
 mod requested_path;
 mod static_handler;
+mod partial_file;

--- a/src/partial_file.rs
+++ b/src/partial_file.rs
@@ -1,0 +1,132 @@
+use std::fs::File;
+use iron::headers::{ByteRangeSpec, ContentLength, ContentRange, ContentRangeSpec};
+use iron::response::{WriteBody, Response};
+use iron::modifier::Modifier;
+use iron::status::Status;
+use std::io::{self, SeekFrom, Seek, Read, Write};
+use std::path::Path;
+
+pub enum PartialFileRange {
+    AllFrom(u64),
+    FromTo(u64,u64),
+    Last(u64),
+}
+
+pub struct PartialFile {
+    file: File,
+    range: PartialFileRange,
+}
+
+struct PartialContentBody {
+    pub file: File,
+    pub offset: u64,
+    pub len: u64,
+}
+
+impl PartialFile {
+    pub fn new<Range>(file: File, range: Range) -> PartialFile
+        where Range: Into<PartialFileRange> {
+        let range = range.into();
+        PartialFile {
+            file: file,
+            range: range,
+        }
+    }
+
+    /// Panics if the file doesn't exist
+    pub fn from_path<P: AsRef<Path>, Range>(path: P, range: Range) -> PartialFile
+    where Range: Into<PartialFileRange> {
+        let file = File::open(path.as_ref())
+            .expect(&format!("No such file: {}", path.as_ref().display()));
+        Self::new(file, range)
+    }
+}
+
+impl From<ByteRangeSpec> for PartialFileRange {
+    fn from(b: ByteRangeSpec) -> PartialFileRange {
+        match b {
+            ByteRangeSpec::AllFrom(from) => PartialFileRange::AllFrom(from),
+            ByteRangeSpec::FromTo(from, to) => PartialFileRange::FromTo(from, to),
+            ByteRangeSpec::Last(last) => PartialFileRange::Last(last),
+        }
+    }
+}
+
+impl From<Vec<ByteRangeSpec>> for PartialFileRange {
+    fn from(v: Vec<ByteRangeSpec>) -> PartialFileRange {
+        match v.into_iter().next() {
+            // in the case no value is in "Range", return
+            // the whole file instead of panicking
+            // Note that an empty vec should never happen,
+            // but we can never be too sure
+            None => PartialFileRange::AllFrom(0),
+            Some(byte_range) => PartialFileRange::from(byte_range),
+        }
+    }
+}
+
+impl Modifier<Response> for PartialFile {
+    #[inline]
+    fn modify(self, res: &mut Response) {
+        use self::PartialFileRange::*;
+        let metadata : Option<_> = self.file.metadata().ok();
+        let file_length : Option<u64> = metadata.map(|m| m.len());
+        let range : Option<(u64, u64)> = match (self.range, file_length) {
+            (FromTo(from, to), Some(file_length)) => {
+                if from <= to && to < file_length {
+                    Some((from, to))
+                } else {
+                    None
+                }
+            },
+            (AllFrom(from), Some(file_length)) => {
+                if from < file_length {
+                    Some((from, file_length - 1))
+                } else {
+                    None
+                }
+            },
+            (Last(last), Some(file_length)) => {
+                if last < file_length {
+                    Some((file_length - last, file_length - 1))
+                } else {
+                    Some((0, file_length - 1))
+                }
+            },
+            (_, None) => None,
+            
+        };
+        if let Some(range) = range {
+            let content_range = ContentRange(ContentRangeSpec::Bytes {
+                range: Some(range),
+                instance_length: file_length,
+            });
+            let content_len = range.1 - range.0 + 1;
+            res.headers.set(ContentLength(content_len));
+            res.headers.set(content_range);
+            let partial_content = PartialContentBody {
+                file: self.file,
+                offset: range.0,
+                len: content_len,
+            };
+            res.status = Some(Status::PartialContent);
+            res.body = Some(Box::new(partial_content));
+        } else {
+            if let Some(file_length) = file_length {
+                res.headers.set(ContentRange(ContentRangeSpec::Bytes {
+                    range: None,
+                    instance_length: Some(file_length),
+                }));
+            };
+            res.status = Some(Status::RangeNotSatisfiable);
+        }
+    }
+}
+
+impl WriteBody for PartialContentBody {
+    fn write_body(&mut self, res: &mut Write) -> io::Result<()> {
+        self.file.seek(SeekFrom::Start(self.offset))?;
+        let mut limiter = <File as Read>::by_ref(&mut self.file).take(self.len);
+        io::copy(&mut limiter, res).map(|_| ())
+    }
+}


### PR DESCRIPTION
This commits adds Partial Content Delivery, as asked in issue #93. This
enables the "Accept-Ranges" header on all files delivered via
static. It is possible to ask only a certain portion of bytes like
explicitely described in RFC 7233. Of the 3 ways to ask for a range of
bytes (byte x to byte y, everything from byte x to end of file, last y
bytes from end of file), every one of them is implemented, but if a
request is to ask multi ranges in a same request, this implementation
will only account the first range.

---- end of commit ----

Quite a big PR I have here, I hope it's not too much hassle. If you think there are better ways to structure my code, please tell me I'll fix that right away ! What is good coding to me might not be for iron, and I'm fine with that !

So basically it closes partially #93 . It works for a single range, but multiple ranges are not yet supported (that's why it doesn't close #93 totally in my opinion). Video seeking works fine though, in firefox, chrome or mpv, or whatever.

I'm missing tests as well, and I'd like support on that part. I must say that I'm not familiar with `iron_test` and your way of testing, and I don't really know *what* to test either. So if someone could comment on that part, that'd be nice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iron/staticfile/95)
<!-- Reviewable:end -->
