### PR TITLE
WIP: Changes for the upcoming iron 0.7 release with hyper 0.12

### DIFF
--- a/examples/doc_server.rs
+++ b/examples/doc_server.rs
@@ -25,5 +25,5 @@ fn main() {
 
     println!("Doc server running on http://localhost:3000/doc/");
 
-    Iron::new(mount).http("127.0.0.1:3000").unwrap();
+    Iron::new(mount).http("127.0.0.1:3000");
 }

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -17,7 +17,7 @@ extern crate mount;
 extern crate router;
 extern crate staticfile;
 
-use iron::status;
+use iron::StatusCode;
 use iron::{Iron, Request, Response, IronResult};
 
 use mount::Mount;
@@ -28,7 +28,7 @@ use std::path::Path;
 
 fn say_hello(req: &mut Request) -> IronResult<Response> {
     println!("Running send_hello handler, URL path: {}", req.url.path().join("/"));
-    Ok(Response::with((status::Ok, "This request was routed!")))
+    Ok(Response::with((StatusCode::OK, "This request was routed!")))
 }
 
 fn main() {
@@ -41,5 +41,5 @@ fn main() {
         .mount("/", router)
         .mount("/docs/", Static::new(Path::new("target/doc")));
 
-    Iron::new(mount).http("127.0.0.1:3000").unwrap();
+    Iron::new(mount).http("127.0.0.1:3000");
 }

--- a/src/httpdate.rs
+++ b/src/httpdate.rs
@@ -1,0 +1,120 @@
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use time;
+
+/// A timestamp with HTTP formatting and parsing
+//   Prior to 1995, there were three different formats commonly used by
+//   servers to communicate timestamps.  For compatibility with old
+//   implementations, all three are defined here.  The preferred format is
+//   a fixed-length and single-zone subset of the date and time
+//   specification used by the Internet Message Format [RFC5322].
+//
+//     HTTP-date    = IMF-fixdate / obs-date
+//
+//   An example of the preferred format is
+//
+//     Sun, 06 Nov 1994 08:49:37 GMT    ; IMF-fixdate
+//
+//   Examples of the two obsolete formats are
+//
+//     Sunday, 06-Nov-94 08:49:37 GMT   ; obsolete RFC 850 format
+//     Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
+//
+//   A recipient that parses a timestamp value in an HTTP header field
+//   MUST accept all three HTTP-date formats.  When a sender generates a
+//   header field that contains one or more timestamps defined as
+//   HTTP-date, the sender MUST generate those timestamps in the
+//   IMF-fixdate format.
+//
+//   This code is based on `src/hyper/header/shared/httpdate.rs` from
+//   hyper 0.11 (https://github.com/hyperium/hyper)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct HttpDate(pub time::Tm);
+
+impl FromStr for HttpDate {
+    type Err = ();
+    fn from_str(s: &str) -> Result<HttpDate, ()> {
+        match time::strptime(s, "%a, %d %b %Y %T %Z").or_else(|_| {
+            time::strptime(s, "%A, %d-%b-%y %T %Z")
+        }).or_else(|_| {
+            time::strptime(s, "%c")
+        }) {
+            Ok(t) => Ok(HttpDate(t)),
+            Err(_) => Err(()),
+        }
+    }
+}
+
+impl Display for HttpDate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0.to_utc().rfc822(), f)
+    }
+}
+
+impl From<SystemTime> for HttpDate {
+    fn from(sys: SystemTime) -> HttpDate {
+        let tmspec = match sys.duration_since(UNIX_EPOCH) {
+            Ok(dur) => {
+                time::Timespec::new(dur.as_secs() as i64, dur.subsec_nanos() as i32)
+            },
+            Err(err) => {
+                let neg = err.duration();
+                time::Timespec::new(-(neg.as_secs() as i64), -(neg.subsec_nanos() as i32))
+            },
+        };
+        HttpDate(time::at_utc(tmspec))
+    }
+}
+
+impl From<HttpDate> for SystemTime {
+    fn from(date: HttpDate) -> SystemTime {
+        let spec = date.0.to_timespec();
+        if spec.sec >= 0 {
+            UNIX_EPOCH + Duration::new(spec.sec as u64, spec.nsec as u32)
+        } else {
+            UNIX_EPOCH - Duration::new(spec.sec as u64, spec.nsec as u32)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use time::Tm;
+    use super::HttpDate;
+
+    const NOV_07: HttpDate = HttpDate(Tm {
+        tm_nsec: 0,
+        tm_sec: 37,
+        tm_min: 48,
+        tm_hour: 8,
+        tm_mday: 7,
+        tm_mon: 10,
+        tm_year: 94,
+        tm_wday: 0,
+        tm_isdst: 0,
+        tm_yday: 0,
+        tm_utcoff: 0,
+    });
+
+    #[test]
+    fn test_imf_fixdate() {
+        assert_eq!("Sun, 07 Nov 1994 08:48:37 GMT".parse::<HttpDate>().unwrap(), NOV_07);
+    }
+
+    #[test]
+    fn test_rfc_850() {
+        assert_eq!("Sunday, 07-Nov-94 08:48:37 GMT".parse::<HttpDate>().unwrap(), NOV_07);
+    }
+
+    #[test]
+    fn test_asctime() {
+        assert_eq!("Sun Nov  7 08:48:37 1994".parse::<HttpDate>().unwrap(), NOV_07);
+    }
+
+    #[test]
+    fn test_no_date() {
+        assert!("this-is-no-date".parse::<HttpDate>().is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,4 @@ pub use static_handler::Cache;
 
 mod requested_path;
 mod static_handler;
+mod httpdate;


### PR DESCRIPTION
This PR contains all the changes necessary for `staticfile` to work with the new `iron` crate based on `hyper` 0.12. 

However, the tests are not updated so far, as they need the crate `iron_test` to be updated, which has not happend so far. Thus, I marked this PR as WIP for now, but if we want to release without updating `iron_test`, we could also drop the tests for now.

In order to get everything working, I copied the source of HttpDate from hyper 0.11 ([src/hyper/header/shared/httpdate.rs](https://docs.rs/hyper/0.11.27/src/hyper/header/shared/httpdate.rs.html)). Since this crate and hyper are both MIT licensed, I hope this should pose no problem.